### PR TITLE
Draft: add init_draft_statusbar to CMakeLists

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -50,6 +50,7 @@ SET(Draft_tests
 SET(Draft_utilities
     draftutils/__init__.py
     draftutils/init_tools.py
+    draftutils/init_draft_statusbar.py
     draftutils/utils.py
     draftutils/gui_utils.py
     draftutils/todo.py


### PR DESCRIPTION
New files added to the source code need to be included in the `CMakeLists.txt` file so that when compiling the source, the new file is moved to the build directory appropriately. Otherwise the new file won't be found.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists